### PR TITLE
Parameter `browser` in `file_show()` fixed

### DIFF
--- a/R/file.R
+++ b/R/file.R
@@ -153,7 +153,7 @@ file_show <- function(path = ".", browser = getOption("browser")) {
   old <- path_expand(path)
 
   for (p in path) {
-    browseURL(p)
+    browseURL(p, browser = browser)
   }
 
   invisible(path_tidy(path))


### PR DESCRIPTION
The parameter `browser` was not used in the body the function `file_show()`.